### PR TITLE
Multiple instances: move module name creation into function and use it

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -667,13 +667,9 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
     
       /* get arrow icon widget */
       wlabel = g_list_nth(gtk_container_get_children(GTK_CONTAINER(header)),5)->data;
-      char label[128];
-      if(strcmp(module->multi_name,"0") == 0)
-        g_snprintf(label,sizeof(label),"<span size=\"larger\">%s</span>  ",module->name());
-      else
-        g_snprintf(label,sizeof(label),"<span size=\"larger\">%s</span> %s",module->name(),module->multi_name);
-      gtk_label_set_markup(GTK_LABEL(wlabel),label);
-  
+      gchar *label = dt_history_item_get_name_html(module);
+      gtk_label_set_markup(GTK_LABEL(wlabel), label);
+      g_free(label);
     }
     modules = g_list_next(modules);
   }
@@ -1145,7 +1141,9 @@ void dt_dev_get_pointer_zoom_pos(dt_develop_t *dev, const float px, const float 
 
 void dt_dev_get_history_item_label(dt_dev_history_item_t *hist, char *label, const int cnt)
 {
-  g_snprintf(label, cnt, "%s (%s)", hist->module->name(), hist->enabled ? _("on") : _("off"));
+  gchar *module_label = dt_history_item_get_name(hist->module);
+  g_snprintf(label, cnt, "%s (%s)", module_label, hist->enabled ? _("on") : _("off"));
+  g_free(module_label);
 }
 
 int
@@ -1440,6 +1438,26 @@ void dt_dev_modules_update_multishow(dt_develop_t *dev)
     dt_dev_module_update_multishow(dev,mod);
     modules = g_list_next(modules);
   }
+}
+gchar *dt_history_item_get_name(struct dt_iop_module_t *module)
+{
+  gchar *label;
+  /* create a history button and add to box */
+  if(!module->multi_name[0] || strcmp(module->multi_name, "0") == 0)
+    label = g_strdup_printf("%s", module->name());
+  else
+    label = g_strdup_printf("%s %s", module->name(), module->multi_name);
+  return label;
+}
+gchar *dt_history_item_get_name_html(struct dt_iop_module_t *module)
+{
+  gchar *label;
+  /* create a history button and add to box */
+  if(!module->multi_name[0] || strcmp(module->multi_name, "0") == 0)
+    label = g_strdup_printf("<span size=\"larger\">%s</span>", module->name());
+  else
+    label = g_strdup_printf("<span size=\"larger\">%s</span> %s", module->name(), module->multi_name);
+  return label;
 }
 
 int dt_dev_distort_transform(dt_develop_t *dev, float *points, size_t points_count)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -276,6 +276,9 @@ void dt_dev_module_remove(dt_develop_t *dev, struct dt_iop_module_t *module);
 void dt_dev_module_update_multishow(dt_develop_t *dev, struct dt_iop_module_t *module);
 /** same, but for all modules */
 void dt_dev_modules_update_multishow(dt_develop_t *dev);
+/** generates item multi-instance name */
+gchar *dt_history_item_get_name(struct dt_iop_module_t *module);
+gchar *dt_history_item_get_name_html(struct dt_iop_module_t *module);
 
 /*
  * distort functions

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -835,7 +835,9 @@ dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user_data)
     dt_dev_add_history_item(module->dev, module, FALSE);
   }
   char tooltip[512];
-  snprintf(tooltip, sizeof(tooltip), module->enabled ? _("%s is switched on") : _("%s is switched off"), module->name());
+  gchar *module_label = dt_history_item_get_name(module);
+  snprintf(tooltip, sizeof(tooltip), module->enabled ? _("%s is switched on") : _("%s is switched off"), module_label);
+  g_free(module_label);
   g_object_set(G_OBJECT(togglebutton), "tooltip-text", tooltip, (char *)NULL);
 }
 
@@ -874,14 +876,10 @@ gboolean dt_iop_shown_in_group(dt_iop_module_t *module, uint32_t group)
 
 static void _iop_panel_label(GtkWidget *lab, dt_iop_module_t *module)
 {
-  char label[128];
-  // if multi_name is emptry or "0"
-  if(!module->multi_name[0] || strcmp(module->multi_name,"0") == 0)
-    g_snprintf(label,sizeof(label),"<span size=\"larger\">%s</span>  ",module->name());
-  else
-    g_snprintf(label,sizeof(label),"<span size=\"larger\">%s</span> %s",module->name(),module->multi_name);
   gtk_widget_set_name(lab, "panel_label");
-  gtk_label_set_markup(GTK_LABEL(lab),label);
+  gchar *label = dt_history_item_get_name_html(module);
+  gtk_label_set_markup(GTK_LABEL(lab), label);
+  g_free(label);
 }
 
 static void _iop_gui_update_header(dt_iop_module_t *module)
@@ -1728,7 +1726,9 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
   /* add enabled button */
   hw[idx] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT|CPF_DO_NOT_USE_BORDER);
   gtk_widget_set_no_show_all(hw[idx],TRUE);
-  snprintf(tooltip, sizeof(tooltip), module->enabled ? _("%s is switched on") : _("%s is switched off"), module->name());
+  gchar *module_label = dt_history_item_get_name(module);
+  snprintf(tooltip, sizeof(tooltip), module->enabled ? _("%s is switched on") : _("%s is switched off"), module_label);
+  g_free(module_label);
   g_object_set(G_OBJECT(hw[idx]), "tooltip-text", tooltip, (char *)NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(hw[idx]), module->enabled);
   g_signal_connect (G_OBJECT (hw[idx]), "toggled",

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -178,7 +178,9 @@ void dt_masks_gui_form_save_creation(dt_iop_module_t *module, dt_masks_form_t *f
       //we create a new group
       if (form->type & DT_MASKS_CLONE) grp = dt_masks_create(DT_MASKS_GROUP | DT_MASKS_CLONE);
       else grp = dt_masks_create(DT_MASKS_GROUP);
-      snprintf(grp->name,sizeof(grp->name),"grp %s %s",module->name(),module->multi_name);
+      gchar *module_label = dt_history_item_get_name(module);
+      snprintf(grp->name,sizeof(grp->name),"grp %s",module_label);
+      g_free(module_label);
       _check_id(grp);
       darktable.develop->forms = g_list_append(darktable.develop->forms,grp);
       module->blend_params->mask_id = grpid = grp->formid;
@@ -1121,7 +1123,9 @@ static void _menu_add_exist(dt_iop_module_t *module, int formid)
   {
     //we create a new group
     grp = dt_masks_create(DT_MASKS_GROUP);
-    snprintf(grp->name,sizeof(grp->name),"grp %s",module->name());
+    gchar *module_label = dt_history_item_get_name(module);
+    snprintf(grp->name,sizeof(grp->name),"grp %s",module_label);
+    g_free(module_label);
     _check_id(grp);
     darktable.develop->forms = g_list_append(darktable.develop->forms,grp);
     module->blend_params->mask_id = grpid = grp->formid;
@@ -1159,7 +1163,9 @@ void dt_masks_iop_use_same_as(dt_iop_module_t *module, dt_iop_module_t *src)
   {
     //we create a new group
     grp = dt_masks_create(DT_MASKS_GROUP);
-    snprintf(grp->name,sizeof(grp->name),"grp %s %s",module->name(),module->multi_name);
+    gchar *module_label = dt_history_item_get_name(module);
+    snprintf(grp->name,sizeof(grp->name),"grp %s",module_label);
+    g_free(module_label);
     _check_id(grp);
     darktable.develop->forms = g_list_append(darktable.develop->forms,grp);
     module->blend_params->mask_id = grpid = grp->formid;
@@ -1275,12 +1281,9 @@ void dt_masks_iop_combo_populate(struct dt_iop_module_t **m)
           dt_bauhaus_combobox_add(combo,str2);
           cids[pos++] = 0;  //nothing to do
         }
-        char str[256] = "";
-        g_strlcat(str,m->name(),sizeof(str));
-        g_strlcat(str," ",sizeof(str));
-        g_strlcat(str,m->multi_name,sizeof(str));
-        g_strlcat(str,"   ",sizeof(str));
-        dt_bauhaus_combobox_add(combo,str);
+        gchar *module_label = dt_history_item_get_name(m);
+        dt_bauhaus_combobox_add(combo, module_label);
+        g_free(module_label);
         cids[pos++] = -1*pos2;
         nb++;
       }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1610,12 +1610,14 @@ dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, void *
     pixelpipe_flow &= ~(PIXELPIPE_FLOW_BLENDED_ON_GPU);
 #endif
 
-    dt_show_times(&start, "[dev_pixelpipe]", "processing `%s' on %s%s%s, blending on %s [%s]", module->name(),
+    gchar *module_label = dt_history_item_get_name(module);
+    dt_show_times(&start, "[dev_pixelpipe]", "processing `%s' on %s%s%s, blending on %s [%s]", module_label,
                   pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_ON_GPU ? "GPU" : pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_ON_CPU ? "CPU" : "",
                   pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_WITH_TILING ? " with tiling" : "",
                   pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_ON_GPU ? ", collecting histogram on GPU" : pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_ON_CPU ? ", collecting histogram on CPU" : "",
                   pixelpipe_flow & PIXELPIPE_FLOW_BLENDED_ON_GPU ? "GPU" : pixelpipe_flow & PIXELPIPE_FLOW_BLENDED_ON_CPU ? "CPU" : "",
                   _pipe_type_to_str(pipe->type));
+    g_free(module_label);
     // in case we get this buffer from the cache, also get the processed max:
     for(int k=0; k<3; k++) piece->processed_maximum[k] = pipe->processed_maximum[k];
     dt_pthread_mutex_unlock(&pipe->busy_mutex);
@@ -1660,10 +1662,12 @@ dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, void *
             }
           }
         }
-        if(hasnan) fprintf(stderr, "[dev_pixelpipe] module `%s' outputs NaNs! [%s]\n", module->name(), _pipe_type_to_str(pipe->type));
-        if(hasinf) fprintf(stderr, "[dev_pixelpipe] module `%s' outputs non-finite floats! [%s]\n", module->name(), _pipe_type_to_str(pipe->type));
-        fprintf(stderr, "[dev_pixelpipe] module `%s' min: (%f; %f; %f) max: (%f; %f; %f) [%s]\n", module->name(),
+        gchar *module_label = dt_history_item_get_name(module);
+        if(hasnan) fprintf(stderr, "[dev_pixelpipe] module `%s' outputs NaNs! [%s]\n", module_label, _pipe_type_to_str(pipe->type));
+        if(hasinf) fprintf(stderr, "[dev_pixelpipe] module `%s' outputs non-finite floats! [%s]\n", module_label, _pipe_type_to_str(pipe->type));
+        fprintf(stderr, "[dev_pixelpipe] module `%s' min: (%f; %f; %f) max: (%f; %f; %f) [%s]\n", module_label,
                 min[0], min[1], min[2], max[0], max[1], max[2], _pipe_type_to_str(pipe->type));
+        g_free(module_label);
       }
       dt_pthread_mutex_unlock(&pipe->busy_mutex);
     }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -189,17 +189,13 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
 
   /* iterate over history items and add them to list*/
   GList *history = g_list_first(darktable.develop->history);
-  char label[512];
   while (history)
   {
     dt_dev_history_item_t *hitem = (dt_dev_history_item_t *)(history->data);
 
-    /* create a history button and add to box */
-    if(strcmp(hitem->module->multi_name,"0") == 0)
-      snprintf(label, sizeof(label), "%s", hitem->module->name());
-    else
-      snprintf(label, sizeof(label), "%s %s", hitem->module->name(), hitem->module->multi_name);
+    gchar *label = dt_history_item_get_name(hitem->module);
     GtkWidget *widget =_lib_history_create_button(self,num,label,hitem->enabled);
+    g_free(label);
 
     gtk_box_pack_start(GTK_BOX(d->history_box),widget,TRUE,TRUE,0);
     gtk_box_reorder_child(GTK_BOX(d->history_box),widget,0);

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -985,7 +985,9 @@ static int _tree_button_pressed (GtkWidget *treeview, GdkEventButton *event, dt_
                   }
                   if (nbuse==0) g_strlcat(str, " (", sizeof(str));
                   g_strlcat(str, " ", sizeof(str));
-                  g_strlcat(str,m->name(),sizeof(str));
+                  gchar *module_label = dt_history_item_get_name(m);
+                  g_strlcat(str, module_label, sizeof(str));
+                  g_free(module_label);
                   nbuse++;
                 }
                 pts = g_list_next(pts);


### PR DESCRIPTION
This replaces all instances of MI-aware module label generation into function calls (how it should have been done initially).
I'm not 100% about masks part - there were some inconsistencies between using module name vs. MI module name.
